### PR TITLE
docs: add Hanzilla Jobs Canada new grad resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ For a complete list, click the following sortable link below:
 </a>
 </div>
 
+
+## Related Canada resource 🇨🇦
+
+- [Hanzilla Jobs](https://jobs.hanzilla.co/new-grad/) - Free daily-updated Canadian student and recent-grad job board for software engineering, data/AI, internships, co-ops, new-grad, junior, and entry-level roles across Canada.
+
 ---
 ## Daily Job List  🌐 🧭 🏆
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a Canada-specific companion resource for students and recent grads.
- Deep-links to the Hanzilla new-grad landing page for Canadian software engineering, data/AI, internship/co-op, new-grad, junior, and entry-level roles.

## Why
This repo is useful for new-grad software engineering discovery. Hanzilla complements it for Canadian students/recent grads who want a daily-updated Canada-focused board across internships, co-ops, new-grad, junior, and entry-level roles.

## Checks
- `git diff --check`
